### PR TITLE
Serbian zipcode have 5 digits

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -121,7 +121,7 @@ module ValidatesZipcode
       AS: /\A96799\z/,
       CC: /\A6799\z/,
       CK: /\A\d{4}\z/,
-      RS: /\A\d{6}\z/,
+      RS: /\A\d{5}\z/,
       ME: /\A8\d{4}\z/,
       CS: /\A\d{5}\z/,
       YU: /\A\d{5}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -95,6 +95,18 @@ describe ValidatesZipcode, '#validate_each' do
     end
   end
 
+  context 'Serbia' do
+    it 'validates with a valid zipcode' do
+      record = build_record('21000', 'RS')
+      zipcode_should_be_valid(record)
+    end
+    
+    it 'does not validate with an invalid zipcode' do
+      record = build_record('2100', 'RS')
+      zipcode_should_be_invalid(record)
+    end
+  end
+  
   context "unknown country" do
     it 'does not add errors with a any zipcode' do
       record = build_record('A1J2Z9', 'ZZ')


### PR DESCRIPTION
Serbian zipcode have 5 digits: http://en.wikipedia.org/wiki/Postal_codes_in_Serbia

First I thought I might have the country code missed up, but this does not seem the case: http://countrycode.org

