### PR TITLE
Change postal code regexp for CZ

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -43,7 +43,7 @@ module ValidatesZipcode
       CL: /\A\d{3}[-]?\d{4}\z/,
       HR: /\A\d{5}\z/,
       CY: /\A\d{4}\z/,
-      CZ: /\A\d{3}[ ]?\d{2}\z/,
+      CZ: /\A[1-7][0-9]{2}[ ]?\d{2}\z/,
       DO: /\A\d{5}\z/,
       EC: /\A([A-Z]\d{4}[A-Z]|(?:[A-Z]{2})?\d{6})?\z/,
       EE: /\A\d{5}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -151,6 +151,20 @@ describe ValidatesZipcode, '#validate_each' do
       zipcode_should_be_invalid(record)
     end
   end
+
+  context 'Czech' do
+    it 'validates with a valid zipcode' do
+      ['12000', '721 00'].each do |zipcode|
+        record = build_record(zipcode, 'CZ')
+        zipcode_should_be_valid(record)
+      end
+    end
+
+    it 'does not validate with an invalid zipcode' do
+      record = build_record('981 32', 'CZ')
+      zipcode_should_be_invalid(record)
+    end
+  end
 end
 
 describe ValidatesZipcode, '.valid?' do


### PR DESCRIPTION
Hello there!

first, thank you for this gem :)

We'v found that czech regexp is not accurate. The first number ca only be 1-7. 0,8,9 are assigned to Slovakia. The current regexp would be valid for CS(Czechoslovakia) but this state splitted into Czech and Slovakia 25y ago. 

Link to wiki:
https://en.wikipedia.org/wiki/Postal_codes_in_the_Czech_Republic

I'v changed the regexp and added some basic test

Thank you