### PR TITLE
Fixed brazilian zipcode regex

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -148,7 +148,7 @@ module ValidatesZipcode
       BI: /\A([a-zA-Z\d\s]){3,}\z/,
       BS: /\A([a-zA-Z\d\s]){3,}\z/,
       BZ: /\A([a-zA-Z\d\s]){3,}\z/,
-      BR: /\A\d{4}[a-zA-Z][\- | [ ]]\d{2}[a-zA-Z]\z/,
+      BR: /\A\d{5}(-?\d{3})?\z/,
       BJ: /\A([a-zA-Z\d\s]){3,}\z/,
       BT: /\A\d{5}\z/,
       BQ: /\A([a-zA-Z\d\s]){3,}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -152,6 +152,20 @@ describe ValidatesZipcode, '#validate_each' do
     end
   end
 
+  context 'Brazil' do
+    it 'validates with a valid zipcode' do
+      ['72315', '72315-500', '72315500', '24210-325', '24210325'].each do |zipcode|
+        record = build_record(zipcode, 'BR')
+        zipcode_should_be_valid(record)
+      end
+    end
+
+    it 'does not validate with an invalid zipcode' do
+      record = build_record('723155', 'BR')
+      zipcode_should_be_invalid(record)
+    end
+  end
+
   context 'Czech' do
     it 'validates with a valid zipcode' do
       ['12000', '721 00'].each do |zipcode|


### PR DESCRIPTION
I believe that the brazilian regex was wrong, so I try to fixed it.

Sources for the regex:

- http://www.grcdi.nl/gsb/brazil.html#H653B4E6D1258E62ABD4015F3B8AEECAE0D18981B03FBrazilA20A2DA20A5BA5BPostalA20codeA20regularA20expressionA5DA5D00700A00D01001301C02302D03A03D
- http://networking.mydesigntool.com/viewtopic.php?tid=419&id=31
- https://helpdesk.coresystems.ch/hc/en-us/articles/201972481-BUP-Validate-Brazilian-ZipCode-CEP-correct-format
- http://www.regexlib.com/REDetails.aspx?regexp_id=767

