### PR TITLE
Fix regex for SE

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -209,7 +209,7 @@ module ValidatesZipcode
       QA: /\A([a-zA-Z\d\s]){3,}\z/,
       RW: /\A([a-zA-Z\d\s]){3,}\z/,
       SC: /\A([a-zA-Z\d\s]){3,}\z/,
-      SE: /\A\d{3}[ ]\d{2}\z/,
+      SE: /\A\d{3}[ ]?\d{2}\z/,
       SK: /\A[089]\d{2}[ ]?\d{2}\z/,
       SL: /\A([a-zA-Z\d\s]){3,}\z/,
       SB: /\A([a-zA-Z\d\s]){3,}\z/,


### PR DESCRIPTION
CLDR specifies the following regex for SE:
`<postCodeRegex territoryId="SE" >\d{3}[ ]?\d{2}</postCodeRegex>`

The pull request fixes the regex making the space optional.