### PR TITLE
update new korea zipcode regex

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -23,7 +23,7 @@ module ValidatesZipcode
       NO: /\A\d{4}\z/,
       FI: /\A\d{5}\z/,
       AX: /\A22\d{3}\z/,
-      KR: /\A(\d{5})|(\d{3}[\-]\d{3})\z/,
+      KR: /\A((\d{5})|(\d{3}[\-]\d{3}))\z/,
       CN: /\A\d{6}\z/,
       SG: /\A\d{6}\z/,
       DZ: /\A\d{5}\z/,

--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -23,7 +23,7 @@ module ValidatesZipcode
       NO: /\A\d{4}\z/,
       FI: /\A\d{5}\z/,
       AX: /\A22\d{3}\z/,
-      KR: /\A\d{3}[\-]\d{3}\z/,
+      KR: /\A(\d{5})|(\d{3}[\-]\d{3})\z/,
       CN: /\A\d{6}\z/,
       SG: /\A\d{6}\z/,
       DZ: /\A\d{5}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -182,6 +182,20 @@ describe ValidatesZipcode, '#validate_each' do
     end
   end
 
+  context 'South Korea' do
+    it 'validates with a valid zipcode' do
+      ['72315', '723-150', '11011', '110-110'].each do |zipcode|
+        record = build_record(zipcode, 'KR')
+        zipcode_should_be_valid(record)
+      end
+    end
+
+    it 'does not validate with an invalid zipcode' do
+      record = build_record('723155', 'KR')
+      zipcode_should_be_invalid(record)
+    end
+  end
+
   context 'Czech' do
     it 'validates with a valid zipcode' do
       ['12000', '721 00'].each do |zipcode|


### PR DESCRIPTION
Recently, Korea updated their zipcode convention to a 5-digit numeric convention. See [this](http://www.fedex.com/tc/koreapostalcode/index.html) or [Wikipedia](https://en.wikipedia.org/wiki/List_of_postal_codes_in_South_Korea).

I made the regex change such that it also applies to the old one. Do you suggest I just go with the new convention altogether?