### PR TITLE
Fix LT zipcode format

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -190,7 +190,7 @@ module ValidatesZipcode
       LI: /\A\d{4}\z/,
       LV: /\A([a-zA-Z]|\d){3,8}\z/,
       LY: /\A\d{5}\z/,
-      LT: /\A([a-zA-Z]){2}(-)\d{4}\z/,
+      LT: /\A([a-zA-Z]){2}(-)\d{4,5}\z/,
       LC: /\A([a-zA-Z\d\s]){3,}\z/,
       MC: /\A\d{5}\z/,
       MD: /\A(([a-zA-Z]){2})(|\s)\d{4}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -134,6 +134,8 @@ describe ValidatesZipcode, '#validate_each' do
     it 'validates with a valid zipcode' do
       record = build_record('LT-0110', 'LT')
       zipcode_should_be_valid(record)
+      record = build_record('LT-00110', 'LT')
+      zipcode_should_be_valid(record)
     end
 
     it 'does not validate with an invalid zipcode' do


### PR DESCRIPTION
Fix issue #18 

Accept both LT-NNNN (until 2005) and LT-NNNNN (post 2005) formats.