### PR TITLE
Fix Israel rules to be compliant with post 2013 format

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -57,7 +57,7 @@ module ValidatesZipcode
       IS: /\A\d{3}\z/,
       IN: /\A\d{6}\z/,
       ID: /\A\d{5}\z/,
-      IL: /\A\d{5}\z/,
+      IL: /\A\d{5,7}\z/,
       JO: /\A\d{5}\z/,
       KZ: /\A\d{6}\z/,
       KE: /\A\d{5}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -223,6 +223,20 @@ describe ValidatesZipcode, '#validate_each' do
       zipcode_should_be_invalid(record)
     end
   end
+
+  context 'Israel' do
+    it 'validates with a valid zipcode' do
+      ['1029200', '880000', '90001'].each do |zipcode|
+        record = build_record(zipcode, 'IL')
+        zipcode_should_be_valid(record)
+      end
+    end
+
+    it 'does not validate with an invalid zipcode' do
+      record = build_record('1200', 'IL')
+      zipcode_should_be_invalid(record)
+    end
+  end
 end
 
 describe ValidatesZipcode, '.valid?' do


### PR DESCRIPTION
Allow 7 digits zipcode to be compatible with post 2013 format, and keep 5 digits legacy format.

Reference: https://en.wikipedia.org/wiki/Postal_codes_in_Israel