### PR TITLE
LU (Luxembourg) Postcode incorrect

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -64,7 +64,7 @@ module ValidatesZipcode
       KW: /\A\d{5}\z/,
       LA: /\A\d{5}\z/,
       LB: /\A(\d{4}([ ]?\d{4})?)?\z/,
-      LU: /\A\d{4}\z/,
+      LU: /\A(L\-)?\d{4}\z/,
       MK: /\A\d{4}\z/,
       MY: /\A\d{5}\z/,
       MV: /\A\d{5}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -10,8 +10,8 @@ describe ValidatesZipcode, '#validate_each' do
     end
 
     it 'adds errors with an invalid Zipcode' do
-      ['124', '12345-12345', 'D0D0D0', '5635', 'invalid_zip'].each do |zipcode|
-        record = build_record(zipcode, 'ES')
+      ['124', '12345-12345', 'D0D0D0', 'invalid_zip'].each do |zipcode|
+        record = build_record(zipcode, 'LU')
         zipcode_should_be_invalid(record, zipcode)
       end
     end

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe ValidatesZipcode, '#validate_each' do
+  context "Luxembourg" do
+    it 'does not add errors with a valid zipcode' do
+      ['L-5635', '5635'].each do |zipcode|
+        record = build_record(zipcode, "LU")
+        zipcode_should_be_valid(record)
+      end
+    end
+
+    it 'adds errors with an invalid Zipcode' do
+      ['124', '12345-12345', 'D0D0D0', '5635', 'invalid_zip'].each do |zipcode|
+        record = build_record(zipcode, 'ES')
+        zipcode_should_be_invalid(record, zipcode)
+      end
+    end
+  end
+
   context "Spain" do
     it 'does not add errors with a valid zipcode' do
       record = build_record('93108', "ES")


### PR DESCRIPTION
Hi, 

The format usually used is "L-XXXX". I have updated the regexp and added the test.

Can you merge this ?
Thank you.

See here : https://www.post.lu/en/grandes-entreprises/solutions-postales/rechercher-un-code-postal