### PR TITLE
Allow any zipcode for Panama as it doesn't have zipcodes

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -205,7 +205,6 @@ module ValidatesZipcode
       NR: /\A([a-zA-Z\d\s]){3,}\z/,
       PT: /\A\d{4}([\-]\d{3})?\z/,
       PS: /\A\d{3}\z/,
-      PA: /\A\d{6}\z/,
       PE: /\A\d{5}\z/,
       QA: /\A([a-zA-Z\d\s]){3,}\z/,
       RW: /\A([a-zA-Z\d\s]){3,}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -255,6 +255,27 @@ describe ValidatesZipcode, '#validate_each' do
       zipcode_should_be_invalid(record)
     end
   end
+
+  context 'countries without a zip code system' do
+    context 'Panama' do
+      let(:country_alpha2) { 'PA' }
+
+      it 'does not any errors with any zipcode' do
+        record = build_record('XYZ123', country_alpha2)
+        zipcode_should_be_valid(record)
+      end
+
+      it 'allows empty string as zipcode' do
+        record = build_record('', country_alpha2)
+        zipcode_should_be_valid(record)
+      end
+
+      it 'allows nil as zipcode' do
+        record = build_record(nil, country_alpha2)
+        zipcode_should_be_valid(record)
+      end
+    end
+  end
 end
 
 describe ValidatesZipcode, '.valid?' do


### PR DESCRIPTION
We use this gem and were contacted by an user complaining that they can't register because Panama doesn't have zip codes but yet one is required. A quick Google search showed that Panama indeed doesn't seem to have zip codes. This change removes the regex for Panama allowing any zip code.