### PR TITLE
Adds excluded_country_codes option ...

### DIFF
--- a/lib/validates_zipcode.rb
+++ b/lib/validates_zipcode.rb
@@ -6,7 +6,7 @@ require "validates_zipcode/version"
 require "validates_zipcode/zipcode"
 
 module ValidatesZipcode
-  def self.valid?(zipcode, country_alpha2)
-    ValidatesZipcode::Zipcode.new(zipcode: zipcode, country_alpha2: country_alpha2).valid?
+  def self.valid?(zipcode, country_alpha2, options = {})
+    ValidatesZipcode::Zipcode.new(options.merge(zipcode: zipcode, country_alpha2: country_alpha2)).valid?
   end
 end

--- a/lib/validates_zipcode/validator.rb
+++ b/lib/validates_zipcode/validator.rb
@@ -17,17 +17,23 @@ require 'active_model/validator'
 module ValidatesZipcode
   class Validator < ActiveModel::EachValidator
     def initialize(options)
-      @country_code           = options.fetch(:country_code) { }
-      @country_code_attribute = options.fetch(:country_code_attribute) { :country_alpha2 }
+      @country_code           = options.fetch(:country_code, nil)
+      @country_code_attribute = options.fetch(:country_code_attribute, :country_alpha2)
+      @excluded_country_codes = options.fetch(:excluded_country_codes, [])
 
       super
     end
 
     def validate_each(record, attribute, value)
-      alpha2 = @country_code || record.send(@country_code_attribute)
+      alpha2  = @country_code || record.send(@country_code_attribute)
+      options = { zipcode: value.to_s,
+                  country_alpha2: alpha2,
+                  excluded_country_codes: @excluded_country_codes }
 
-      unless ValidatesZipcode::Zipcode.new(zipcode: value.to_s, country_alpha2: alpha2).valid?
-        record.errors.add(attribute, :invalid_zipcode, message: I18n.t('errors.messages.invalid_zipcode', value: value, default: 'Zipcode is invalid'))
+      unless ValidatesZipcode::Zipcode.new(options).valid?
+        record.errors.add(attribute, :invalid_zipcode, message: I18n.t('errors.messages.invalid_zipcode',
+                                                       value: value,
+                                                       default: 'Zipcode is invalid'))
       end
     end
   end

--- a/lib/validates_zipcode/zipcode.rb
+++ b/lib/validates_zipcode/zipcode.rb
@@ -3,11 +3,13 @@ module ValidatesZipcode
     include CldrRegexpCollection
 
     def initialize(args = {})
-      @zipcode        = args.fetch(:zipcode)
-      @country_alpha2 = args.fetch(:country_alpha2)
+      @zipcode                = args.fetch(:zipcode)
+      @country_alpha2         = args.fetch(:country_alpha2)
+      @excluded_country_codes = args.fetch(:excluded_country_codes, [])
     end
 
     def valid?
+      return true if @excluded_country_codes.include?(@country_alpha2)
       return true unless regexp
       !!(regexp =~ @zipcode)
     end


### PR DESCRIPTION
…  to be able to configure the validator and avoid some specific country codes. 

Use it like this: 

```
class YourModel
    validates :zipcode, zipcode: { excluded_country_codes: ['PA'] }
end
```

Following up from #25 

@mikkokangasaho can you try this branch and see if this helps you? In that case I'll cut a version and release.