### PR TITLE
Five digits taiwan

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -232,7 +232,7 @@ module ValidatesZipcode
       TO: /\A([a-zA-Z\d\s]){3,}\z/,
       TZ: /\A([a-zA-Z\d\s]){3,}\z/,
       TT: /\A\d{6}\z/,
-      TW: /\A\d{3}\z/,
+      TW: /\A\d{3}(\d{2})?\z/,
       UG: /\A([a-zA-Z\d\s]){3,}\z/,
       UM: /\A([a-zA-Z\d\s]){3,}\z/,
       UY: /\A([a-zA-Z\d\s]){3,}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -263,6 +263,20 @@ describe ValidatesZipcode, '#validate_each' do
     end
   end
 
+  context 'Taiwan' do
+    it 'validates with a valid zipcode' do
+      ['833', '74144'].each do |zipcode|
+        record = build_record(zipcode, 'TW')
+        zipcode_should_be_valid(record)
+      end
+    end
+
+    it 'does not validate with an invalid zipcode' do
+      record = build_record('4329', 'TW')
+      zipcode_should_be_invalid(record, '4329')
+    end
+  end
+
   %w[UK GB].each do |cc|
     context cc do
       it 'validates with a valid zipcode' do


### PR DESCRIPTION
Taiwan zipcode can have 2 more optional digits according to https://en.wikipedia.org/wiki/Postal_codes_in_Taiwan
