### PR TITLE
Make Nicaragua (NI) accept 5-digits zipcodes

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -77,7 +77,7 @@ module ValidatesZipcode
       MX: /\A\d{5}\z/,
       MA: /\A\d{5}\z/,
       NZ: /\A\d{4}\z/,
-      NI: /\A((\d{4}-)?\d{3}-\d{3}(-\d{1})?)?\z/,
+      NI: /\A\d{5}\z/,
       NG: /\A(\d{6})?\z/,
       OM: /\A(PC )?\d{3}\z/,
       PK: /\A\d{5}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -324,6 +324,23 @@ describe ValidatesZipcode, '#validate_each' do
     end
   end
 
+  context 'Nicaragua' do
+    it 'validates with a valid zipcode' do
+      # @see https://en.wikipedia.org/wiki/Postal_codes_in_Nicaragua
+      ['11002', '11034'].each do |zipcode|
+        record = build_record(zipcode, 'NI')
+        zipcode_should_be_valid(record)
+      end
+    end
+
+    it 'does not validate with an invalid zipcode' do
+      ['1002', '111034'].each do |zipcode|
+        record = build_record(zipcode, 'NI')
+        zipcode_should_be_invalid(record, zipcode)
+      end
+    end
+  end
+
   context 'unknown country' do
     it 'does not add errors with a any zipcode' do
       record = build_record('A1J2Z9', 'ZZ')


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Postal_codes_in_Nicaragua), postal codes in Nicaragua are 5 digit numeric. This PR changes it's regex and adds specs