### PR TITLE
modify lithuania regex to make country_code prefix optional

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -196,7 +196,7 @@ module ValidatesZipcode
       LI: /\A\d{4}\z/,
       LV: /\A([a-zA-Z]|\d){3,8}\z/,
       LY: /\A\d{5}\z/,
-      LT: /\A([a-zA-Z]){2}(-)\d{4,5}\z/,
+      LT: /\A(([a-zA-Z]){2}(-))?\d{4,5}\z/,
       LC: /\A([a-zA-Z\d\s]){3,}\z/,
       MC: /\A\d{5}\z/,
       MD: /\A(([a-zA-Z]){2})(|\s)\d{4}\z/,

--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -196,7 +196,7 @@ module ValidatesZipcode
       LI: /\A\d{4}\z/,
       LV: /\A([a-zA-Z]|\d){3,8}\z/,
       LY: /\A\d{5}\z/,
-      LT: /\A(([a-zA-Z]){2}(-))?\d{4,5}\z/,
+      LT: /\A(LT-)?\d{5}\z/,
       LC: /\A([a-zA-Z\d\s]){3,}\z/,
       MC: /\A\d{5}\z/,
       MD: /\A(([a-zA-Z]){2})(|\s)\d{4}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -139,19 +139,19 @@ describe ValidatesZipcode, '#validate_each' do
 
   context 'Lithuania' do
     it 'validates with a valid zipcode' do
-      record = build_record('LT-0110', 'LT')
-      zipcode_should_be_valid(record)
       record = build_record('LT-00110', 'LT')
-      zipcode_should_be_valid(record)
-      record = build_record('0110', 'LT')
       zipcode_should_be_valid(record)
       record = build_record('00110', 'LT')
       zipcode_should_be_valid(record)
     end
 
     it 'does not validate with an invalid zipcode' do
-      record = build_record('210006', 'LT')
-      zipcode_should_be_invalid(record, '210006')
+      record = build_record('2100', 'LT')
+      zipcode_should_be_invalid(record, '2100')
+      record = build_record('LT-2100', 'LT')
+      zipcode_should_be_invalid(record, 'LT-2100')
+      record = build_record('LT21006', 'LT')
+      zipcode_should_be_invalid(record, 'LT21006')
     end
   end
 

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -143,11 +143,15 @@ describe ValidatesZipcode, '#validate_each' do
       zipcode_should_be_valid(record)
       record = build_record('LT-00110', 'LT')
       zipcode_should_be_valid(record)
+      record = build_record('0110', 'LT')
+      zipcode_should_be_valid(record)
+      record = build_record('00110', 'LT')
+      zipcode_should_be_valid(record)
     end
 
     it 'does not validate with an invalid zipcode' do
-      record = build_record('21006', 'LT')
-      zipcode_should_be_invalid(record, '21006')
+      record = build_record('210006', 'LT')
+      zipcode_should_be_invalid(record, '210006')
     end
   end
 


### PR DESCRIPTION
Fix for issue #39 

Accept LT-NNNN/LT-NNNNN and NNNN/NNNNN formats.