### PR TITLE
add zipcode formatting feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.3.0
+
+- Adds zipcode formatting feature ~ @aiomaster
+
 ## 0.2.5
 
 - Allows for a custom message passed to the validator ~ @andychongyz

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Adds zipcode / postal code validation support to Rails (ActiveModel), considerin
 ## Installation
 
 Add this line to your application's Gemfile:
-
-    gem 'validates_zipcode'
+```ruby
+gem 'validates_zipcode'
+```
 
 And then execute:
 
@@ -22,23 +23,56 @@ Or install it yourself as:
 
 ## Usage
 
-    validates_zipcode :zipcode
+### With ActiveModel::Validations
 
-    validates :zipcode, zipcode: true
+```ruby
+validates_zipcode :zipcode
+
+validates :zipcode, zipcode: true
+```
 
 ``ValidatesZipcode`` expects the model to have an attribute called ``country_alpha2`` to contain the country code.
 You can provide your own country_code using ``:country_code`` option, or specify which attribute contains this information
 using ``:country_code_attribute`` option.
 
-    validates :zipcode, zipcode: { country_code: :es }
+```ruby
+validates :zipcode, zipcode: { country_code: :es }
 
-    validates :zipcode, zipcode: { country_code_attribute: :my_country_code_column }
+validates :zipcode, zipcode: { country_code_attribute: :my_country_code_column }
+```
 
 If you need to localize the error message, just add this to your I18n locale file:
 
-    errors:
-      messages:
-        invalid_zipcode: Your zipcode error message.
+```yaml
+errors:
+  messages:
+    invalid_zipcode: Your zipcode error message.
+```
+
+### Without ActiveModel::Validations
+
+```ruby
+ValidatesZipcode.valid?('93108', 'ES')
+# => true
+```
+
+### Formatting
+
+This gem can also be used for formatting zipcodes according to country specific rules.
+
+```ruby
+ValidatesZipcode.format('Sw1A 2aA', 'UK')
+# => 'SW1A 2AA'
+```
+
+If the zipcode is not valid an exception is raised.
+
+```ruby
+ValidatesZipcode.format('Sw1A 2aA', 'FR')
+# => raises ValidatesZipcode::InvalidZipcodeError
+```
+
+At the moment not every country is supported. See [lib/validates_zipcode/formatter.rb](lib/validates_zipcode/formatter.rb) to find all available countries.
 
 ## Contributing
 

--- a/lib/validates_zipcode.rb
+++ b/lib/validates_zipcode.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 require 'validates_zipcode/railtie' if defined?(Rails)
 require 'validates_zipcode/cldr_regex_collection'
+require 'validates_zipcode/invalid_zipcode_error'
 require 'validates_zipcode/validator'
 require 'validates_zipcode/helper_methods'
 require 'validates_zipcode/version'
 require 'validates_zipcode/zipcode'
+require 'validates_zipcode/formatter'
 
 module ValidatesZipcode
-  def self.valid?(zipcode, country_alpha2, options = {})
-    ValidatesZipcode::Zipcode.new(options.merge(zipcode: zipcode, country_alpha2: country_alpha2)).valid?
+  def self.valid?(*args)
+    build_zipcode(*args).valid?
+  end
+
+  def self.format(*args)
+    build_zipcode(*args).format
+  end
+
+  def self.build_zipcode(zipcode, country_alpha2, options = {})
+    ValidatesZipcode::Zipcode.new(options.merge(zipcode: zipcode, country_alpha2: country_alpha2))
   end
 end

--- a/lib/validates_zipcode/formatter.rb
+++ b/lib/validates_zipcode/formatter.rb
@@ -1,0 +1,38 @@
+module ValidatesZipcode
+  class Formatter
+
+    ZIPCODES_TRANSFORMATIONS = {
+      AT: ->(z) { z.scan(/\d/).join },
+      CZ: ->(z) { z.scan(/\d/).insert(3, ' ').join },
+      DE: ->(z) { z.scan(/\d/).join.rjust(5, "0") },
+      GB: ->(z) { z.upcase.scan(/[A-Z0-9]/).insert(-4, ' ').join },
+      NL: ->(z) { z.upcase.scan(/[A-Z0-9]/).insert(4, ' ').join },
+      PL: ->(z) { z.scan(/\d/).insert(2, '-').join },
+      SK: :CZ,
+      UK: :GB,
+      US: ->(z) {
+        digits = z.scan(/\d/)
+        digits.insert(5, '-') if digits.count > 5
+        digits.join
+      }
+    }
+
+    def initialize(args = {})
+      @zipcode        = args.fetch(:zipcode).to_s
+      @country_alpha2 = args.fetch(:country_alpha2).to_s.upcase.to_sym
+    end
+
+    def format
+      transformation = ZIPCODES_TRANSFORMATIONS[@country_alpha2]
+      case transformation
+      when Proc
+        transformation.call(@zipcode)
+      when Symbol
+        ZIPCODES_TRANSFORMATIONS[transformation].call(@zipcode)
+      else
+        @zipcode.strip
+      end
+    end
+
+  end
+end

--- a/lib/validates_zipcode/invalid_zipcode_error.rb
+++ b/lib/validates_zipcode/invalid_zipcode_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module ValidatesZipcode
+  class InvalidZipcodeError < RuntimeError
+  end
+end

--- a/lib/validates_zipcode/zipcode.rb
+++ b/lib/validates_zipcode/zipcode.rb
@@ -16,6 +16,11 @@ module ValidatesZipcode
     end
     alias_method :validate, :valid?
 
+    def format
+      raise InvalidZipcodeError, "invalid zipcode #{@zipcode} for country #{@country_alpha2.to_s.upcase}" unless valid?
+      Formatter.new(zipcode: @zipcode, country_alpha2: @country_alpha2).format
+    end
+
     private
 
     def regexp

--- a/spec/format_zipcode_spec.rb
+++ b/spec/format_zipcode_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe ValidatesZipcode::Formatter, '#format' do
+  context 'Czech' do
+    it { check_format('CZ', '12000' => '120 00') }
+    it { check_format(:cz, '721 00' => '721 00') }
+  end
+
+  context 'Germany' do
+    it { check_format('DE', 1309 => '01309') }
+  end
+
+  context 'Netherlands' do
+    it { check_format('NL', '1000ap' => '1000 AP') }
+    it { check_format('nl', '9104-BR' => '9104 BR') }
+    it { check_format(:nl, '6832_AM' => '6832 AM') }
+  end
+
+  context 'UK' do
+    it { check_format('UK', 'CB224RG' => 'CB22 4RG') }
+    it { check_format('UK', 'Sw1A 2aA' => 'SW1A 2AA') }
+    it { check_format('GB', 'id11qd' => 'ID1 1QD') }
+  end
+
+  context 'US' do
+    it { check_format('US', '221	62	–	10	10' => '22162-1010') }
+    it { check_format('US', '22162' => '22162') }
+    it { check_format('US', '22162 1010' => '22162-1010') }
+  end
+
+  def check_format(country, formatting)
+    from_zip, to_zip = formatting.first
+    expect(::ValidatesZipcode::Formatter.new(zipcode: from_zip, country_alpha2: country).format).to eq(to_zip)
+  end
+end

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -413,6 +413,16 @@ describe ValidatesZipcode, '.valid?' do
   end
 end
 
+describe ValidatesZipcode, '.format' do
+  it "formats valid zipcodes" do
+    expect(ValidatesZipcode.format('Ka9 2dj', 'UK')).to eq('KA9 2DJ')
+  end
+
+  it "raises for invalid zipcodes" do
+    expect { ValidatesZipcode.format('KA9 1tr', 'DE') }.to raise_error(ValidatesZipcode::InvalidZipcodeError)
+  end
+end
+
 def zipcode_should_be_valid(record, options = {})
   ValidatesZipcode::Validator.new(options.merge(attributes: :zipcode)).validate(record)
 


### PR DESCRIPTION
Start to add support for canonical formatting of country specific zipcodes.
See #43 for the general ideas.