### PR TITLE
Document the `:message` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ validates :zipcode, zipcode: { country_code: :es }
 validates :zipcode, zipcode: { country_code_attribute: :my_country_code_column }
 ```
 
+#### Error Messaging
+
 If you need to localize the error message, just add this to your I18n locale file:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ errors:
     invalid_zipcode: Your zipcode error message.
 ```
 
+You can override this on a per-model basis by passing in a ``:message`` key with the validation:
+
+```ruby
+validates :zipcode, zipcode: { message: 'Your per-model zipcode error message.' }
+```
+
 ### Without ActiveModel::Validations
 
 ```ruby


### PR DESCRIPTION
**Description**

After version `0.2.4`, a [`:message` option can be passed into the validation declaration](https://github.com/dgilperez/validates_zipcode/pull/46), to set a custom error message on a per-model basis.

This PR documents that change in the `README`. This closes #47.