### PR TITLE
Dutch zipcodes never start with a ‘0’ or contain the letter combinations 'SS', 'SD' and 'SA’.

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -21,7 +21,7 @@ module ValidatesZipcode
       CH: /\A\d{4}\z/,
       AT: /\A\d{4}\z/,
       ES: /\A\d{5}\z/,
-      NL: /\A\d{4}[ ]?[A-Z]{2}\z/,
+      NL: /\A[1-9]\d{3}[ ]?(?!SA|SD|SS)[A-Z]{2}\z/,
       BE: /\A\d{4}\z/,
       DK: /\A\d{4}\z/,
       NO: /\A\d{4}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -201,6 +201,19 @@ describe ValidatesZipcode, '#validate_each' do
     end
   end
 
+  context 'Netherlands' do
+    it 'does not add errors with a valid zipcode' do
+      record = build_record('1001 AA', 'NL')
+      zipcode_should_be_valid(record)
+    end
+
+    it 'adds errors with an invalid Zipcode' do
+      ['0100 AA', '1001 SS', 'invalid_zip'].each do |zipcode|
+        record = build_record(zipcode, 'NL')
+        zipcode_should_be_invalid(record, zipcode)
+      end
+    end
+  end
   context 'Panama' do
     it 'validates with a valid zipcode' do
       %w[0800 6369].each do |zipcode|


### PR DESCRIPTION

See: [https://nl.wikipedia.org/wiki/Postcodes_in_Nederland](https://nl.wikipedia.org/wiki/Postcodes_in_Nederland) the English translation of this page unfortunately did not add this information.