### PR TITLE
Add formatter for Canada zipcode

### DIFF
--- a/lib/validates_zipcode/formatter.rb
+++ b/lib/validates_zipcode/formatter.rb
@@ -1,12 +1,15 @@
 module ValidatesZipcode
   class Formatter
 
+    WORD_CHAR_AND_DIGIT = /[A-Z0-9]/
+
     ZIPCODES_TRANSFORMATIONS = {
       AT: ->(z) { z.scan(/\d/).join },
+      CA: ->(z) { z.upcase.scan(WORD_CHAR_AND_DIGIT).insert(3, ' ').join },
       CZ: ->(z) { z.scan(/\d/).insert(3, ' ').join },
       DE: ->(z) { z.scan(/\d/).join.rjust(5, "0") },
-      GB: ->(z) { z.upcase.scan(/[A-Z0-9]/).insert(-4, ' ').join },
-      NL: ->(z) { z.upcase.scan(/[A-Z0-9]/).insert(4, ' ').join },
+      GB: ->(z) { z.upcase.scan(WORD_CHAR_AND_DIGIT).insert(-4, ' ').join },
+      NL: ->(z) { z.upcase.scan(WORD_CHAR_AND_DIGIT).insert(4, ' ').join },
       PL: ->(z) { z.scan(/\d/).insert(2, '-').join },
       SK: :CZ,
       UK: :GB,

--- a/spec/format_zipcode_spec.rb
+++ b/spec/format_zipcode_spec.rb
@@ -2,6 +2,12 @@
 require 'spec_helper'
 
 describe ValidatesZipcode::Formatter, '#format' do
+  context 'Canada' do
+    it { check_format('CA', 'l3b3z6' => 'L3B 3Z6') }
+    it { check_format('ca', 'V2r-1c8' => 'V2R 1C8') }
+    it { check_format(:ca, 'g9a 5w1' => 'G9A 5W1') }
+  end
+
   context 'Czech' do
     it { check_format('CZ', '12000' => '120 00') }
     it { check_format(:cz, '721 00' => '721 00') }


### PR DESCRIPTION
## The problem
Got issues on deal with lowercase canadian zipcodes.

E.g.
```ruby
ValidatesZipcode::Zipcode.new(zipcode: 'L3B 3Z6', country_alpha2: 'CA').valid?
# true

ValidatesZipcode::Zipcode.new(zipcode: 'l3b 3z6', country_alpha2: 'CA').valid?
# false
```

When I've tried to use a formatter for that I realized that we don't have one 😄 .

```ruby
ValidatesZipcode.format('l3b 3z6', 'CA')
# ValidatesZipcode::InvalidZipcodeError: invalid zipcode l3b 3z6 for country CA
```

## This solution
Added a new formatter for canadian zipcodes.