### PR TITLE
Make Netherlands regexp compatible with random_example method

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -21,7 +21,7 @@ module ValidatesZipcode
       CH: /\A\d{4}\z/,
       AT: /\A\d{4}\z/,
       ES: /\A\d{5}\z/,
-      NL: /\A[1-9]\d{3}[ ]?(?!SA|SD|SS)[A-Z]{2}\z/,
+      NL: /\A[1-9]\d{3}[ ]?[A-RT-Z][BCE-RT-Z]\z/,
       BE: /\A\d{4}\z/,
       DK: /\A\d{4}\z/,
       NO: /\A\d{4}\z/,

--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -21,7 +21,7 @@ module ValidatesZipcode
       CH: /\A\d{4}\z/,
       AT: /\A\d{4}\z/,
       ES: /\A\d{5}\z/,
-      NL: /\A[1-9]\d{3}[ ]?[A-RT-Z][BCE-RT-Z]\z/,
+      NL: /\A[1-9]\d{3}[ ]?(S[BCE-RT-Z]|[A-RT-Z][A-Z])\z/,
       BE: /\A\d{4}\z/,
       DK: /\A\d{4}\z/,
       NO: /\A\d{4}\z/,

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -208,7 +208,7 @@ describe ValidatesZipcode, '#validate_each' do
     end
 
     it 'adds errors with an invalid Zipcode' do
-      ['0100 AA', '1001 SS', 'invalid_zip'].each do |zipcode|
+      ['0100 AA', '1001 SS', '1111 SD', '1001 SA', 'invalid_zip'].each do |zipcode|
         record = build_record(zipcode, 'NL')
         zipcode_should_be_invalid(record, zipcode)
       end


### PR DESCRIPTION
Fix error with Netherlands zip code generation, removed lookahead from regexp