### PR TITLE
Add a format option that allows formatting postcodes before checking for validity

### DIFF
--- a/lib/validates_zipcode/formatter.rb
+++ b/lib/validates_zipcode/formatter.rb
@@ -7,7 +7,12 @@ module ValidatesZipcode
       AT: ->(z) { z.scan(/\d/).join },
       CA: ->(z) { z.upcase.scan(WORD_CHAR_AND_DIGIT).insert(3, ' ').join },
       CZ: ->(z) { z.scan(/\d/).insert(3, ' ').join },
-      DE: ->(z) { z.scan(/\d/).join.rjust(5, '0') },
+      DE: ->(z) {
+        digits = z.scan(/\d/)
+        result = digits.join
+        result.prepend('0') if digits.count < 5
+        result
+      },
       GB: ->(z) { z.upcase.scan(WORD_CHAR_AND_DIGIT).insert(-4, ' ').join },
       NL: ->(z) { z.upcase.scan(WORD_CHAR_AND_DIGIT).insert(4, ' ').join },
       PL: ->(z) { z.scan(/\d/).insert(2, '-').join },

--- a/lib/validates_zipcode/validator.rb
+++ b/lib/validates_zipcode/validator.rb
@@ -21,6 +21,7 @@ module ValidatesZipcode
       @country_code           = options.fetch(:country_code, nil)
       @country_code_attribute = options.fetch(:country_code_attribute, :country_alpha2)
       @excluded_country_codes = options.fetch(:excluded_country_codes, [])
+      @format                 = options.fetch(:format, false)
       @message                = options.fetch(:message, nil)
       super
     end
@@ -29,7 +30,9 @@ module ValidatesZipcode
       alpha2  = @country_code || record.send(@country_code_attribute)
       options = { zipcode: value.to_s,
                   country_alpha2: alpha2,
-                  excluded_country_codes: @excluded_country_codes }
+                  excluded_country_codes: @excluded_country_codes,
+                  format: @format
+      }
 
       unless ValidatesZipcode::Zipcode.new(options).valid?
         message = @message || I18n.t('errors.messages.invalid_zipcode', value: value, default: 'Zipcode is invalid')

--- a/lib/validates_zipcode/zipcode.rb
+++ b/lib/validates_zipcode/zipcode.rb
@@ -20,11 +20,10 @@ module ValidatesZipcode
     alias_method :validate, :valid?
 
     def format
-      formatted_zip
       @format = true
-      raise InvalidZipcodeError, "invalid zipcode #{@formatted_zip} for country #{@country_alpha2.to_s.upcase}" unless valid?
+      raise InvalidZipcodeError, "invalid zipcode #{formatted_zip} for country #{@country_alpha2.to_s.upcase}" unless valid?
 
-      @formatted_zip
+      formatted_zip
     end
 
     private

--- a/lib/validates_zipcode/zipcode.rb
+++ b/lib/validates_zipcode/zipcode.rb
@@ -10,17 +10,17 @@ module ValidatesZipcode
       @format                 = args.fetch(:format, false)
     end
 
-    def valid?(zipcode = nil)
+    def valid?
       return true if @excluded_country_codes.include?(@country_alpha2)
       return true unless regexp
 
-      zipcode ||= @format ? formatted_zip : @zipcode
+      zipcode = @format ? formatted_zip : @zipcode
       !!(regexp =~ zipcode)
     end
     alias_method :validate, :valid?
 
     def format
-      raise InvalidZipcodeError, "invalid zipcode #{@zipcode} for country #{@country_alpha2.to_s.upcase}" unless valid?(formatted_zip)
+      raise InvalidZipcodeError, "invalid zipcode #{@zipcode} for country #{@country_alpha2.to_s.upcase}" unless valid?
 
       formatted_zip
     end

--- a/lib/validates_zipcode/zipcode.rb
+++ b/lib/validates_zipcode/zipcode.rb
@@ -20,9 +20,11 @@ module ValidatesZipcode
     alias_method :validate, :valid?
 
     def format
-      raise InvalidZipcodeError, "invalid zipcode #{@zipcode} for country #{@country_alpha2.to_s.upcase}" unless valid?
-
       formatted_zip
+      @format = true
+      raise InvalidZipcodeError, "invalid zipcode #{@formatted_zip} for country #{@country_alpha2.to_s.upcase}" unless valid?
+
+      @formatted_zip
     end
 
     private

--- a/lib/validates_zipcode/zipcode.rb
+++ b/lib/validates_zipcode/zipcode.rb
@@ -7,24 +7,32 @@ module ValidatesZipcode
       @zipcode                = args.fetch(:zipcode)
       @country_alpha2         = args.fetch(:country_alpha2)
       @excluded_country_codes = args.fetch(:excluded_country_codes, [])
+      @format                 = args.fetch(:format, false)
     end
 
-    def valid?
+    def valid?(zipcode = nil)
       return true if @excluded_country_codes.include?(@country_alpha2)
       return true unless regexp
-      !!(regexp =~ @zipcode)
+
+      zipcode ||= @format ? formatted_zip : @zipcode
+      !!(regexp =~ zipcode)
     end
     alias_method :validate, :valid?
 
     def format
-      raise InvalidZipcodeError, "invalid zipcode #{@zipcode} for country #{@country_alpha2.to_s.upcase}" unless valid?
-      Formatter.new(zipcode: @zipcode, country_alpha2: @country_alpha2).format
+      raise InvalidZipcodeError, "invalid zipcode #{@zipcode} for country #{@country_alpha2.to_s.upcase}" unless valid?(formatted_zip)
+
+      formatted_zip
     end
 
     private
 
     def regexp
       @regexp ||= regexp_for_country_alpha2(@country_alpha2)
+    end
+
+    def formatted_zip
+      @formatted_zip ||= Formatter.new(zipcode: @zipcode, country_alpha2: @country_alpha2).format
     end
   end
 end


### PR DESCRIPTION
Following our discussion on Issue #56 I'm proposing the following changes:

* Add a format option. This option is a boolean. If it's set to `true`, the postcode will be formatted before being validated. By default it's false, which is the current behaviour (= validate what the user entered without formatting it).
* Modify `Zipcode#format` so that the zipcode validation happens on the formatted zipcode instead.
* Modify the German postcode formatting to not substitute 0 to all missing digits. Instead, it's only adding one 0 when the digit count is less than 5 to allow translation of older East Germany postcodes. This avoids the issue explained [here](https://github.com/dgilperez/validates_zipcode/issues/56#issuecomment-847654208).

This means that now `ValidatesZipcode::Formatter.new(zipcode: 'V2r-1c8', country_alpha2: 'CA').format` and `ValidatesZipcode.format('V2r-1c8', 'CA')` gives the same result.

Similarly, now `ValidatesZipcode.valid?('V2r-1c8', 'CA', format: true)` returns `true` while the default `ValidatesZipcode.valid?('V2r-1c8', 'CA')` still returns `false`.

I hope this helps! Please correct me if I'm wrong or if you'd like things done differently.