### PR TITLE
Puerto Rico uses the same formatting as the US

### DIFF
--- a/lib/validates_zipcode/formatter.rb
+++ b/lib/validates_zipcode/formatter.rb
@@ -30,7 +30,8 @@ module ValidatesZipcode
         digits = z.scan(/\d/)
         digits.insert(5, '-') if digits.count > 5
         digits.join
-      }
+      },
+      PR: :US
     }.freeze
 
     def initialize(args = {})


### PR DESCRIPTION
Puerto Rico uses the same formatting as the US does for postal codes. 
https://en.wikipedia.org/wiki/Postal_codes_in_Puerto_Rico

This change adds formatter support for PR.