### PR TITLE
Honduras has transitioned to 5-digit numeric postal codes

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -185,7 +185,7 @@ module ValidatesZipcode
       GI: /\A(GX11[ ]?1AA)\z/i,
       GR: /\A\d{3}[ ]?\d{2}\z/,
       GY: /\A([A-Z\d\s]){3,}\z/i,
-      HN: /\A(([A-Z]){2}|\d{1,2})\d{4}\z/i,
+      HN: /\A([A-Z]{2}|\d{1})\d{4}\z/i,
       IO: /\A\d{5}\z/,
       IR: /\A\d{5}\z/,
       JP: /\A\d{3}\-?\d{4}\z/,

--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -185,7 +185,7 @@ module ValidatesZipcode
       GI: /\A(GX11[ ]?1AA)\z/i,
       GR: /\A\d{3}[ ]?\d{2}\z/,
       GY: /\A([A-Z\d\s]){3,}\z/i,
-      HN: /\A(([A-Z]){2}|\d{2})\d{4}\z/i,
+      HN: /\A(([A-Z]){2}|\d{1,2})\d{4}\z/i,
       IO: /\A\d{5}\z/,
       IR: /\A\d{5}\z/,
       JP: /\A\d{3}\-?\d{4}\z/,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2628,6 +2628,7 @@ TEST_DATA = {
     valid: %w[
       BV2722
       XY1234
+      12345
     ],
     invalid: [
       nil,
@@ -2635,7 +2636,8 @@ TEST_DATA = {
       'invalid_zip',
       'B2722',
       'XY12345',
-      'XY123'
+      'XY123',
+      '123456'
     ]
   },
   IO: {


### PR DESCRIPTION
Honduras appears to have transitions to a 5-digit numeric postal code.
https://en.youbianku.com/honduras
(See the Note under the Coding Method and the examples in List of Postcodes)

This change add support for the 5-digit numeric postal code. I wasn't sure if support for the old codes should be removed so I left it.