### PR TITLE
Maltese ZIP formatting

### DIFF
--- a/lib/validates_zipcode/formatter.rb
+++ b/lib/validates_zipcode/formatter.rb
@@ -19,7 +19,7 @@ module ValidatesZipcode
       PL: ->(z) { z.scan(/\d/).insert(2, '-').join },
       SK: :CZ,
       UK: :GB,
-      MT: :GB,
+      MT: ->(z) { z.upcase.scan(WORD_CHAR_AND_DIGIT).insert(3, ' ').join },
       FK: :GB,
       GS: :GB,
       PN: :GB,

--- a/spec/format_zipcode_spec.rb
+++ b/spec/format_zipcode_spec.rb
@@ -35,6 +35,10 @@ describe ValidatesZipcode::Formatter, '#format' do
     it { check_format('US', '22162 1010' => '22162-1010') }
   end
 
+  context 'MT' do
+    it { check_format('MT', 'GZR1020' => 'GZR 1020') }
+  end
+
   def check_format(country, formatting)
     from_zip, to_zip = formatting.first
     expect(::ValidatesZipcode::Formatter.new(zipcode: from_zip, country_alpha2: country).format).to eq(to_zip)


### PR DESCRIPTION
👋 
Adjusts `ValidatesZipcode::Formatter::ZIPCODES_TRANSFORMATIONS::MT` to match `ValidatesZipcode::CldrRegexpCollection::ZIPCODES_REGEX::MT`.

Currently the formatter changes the format from (e.g.) `GZR1020` to `GZR1 020`, but the regexp validates that the ZIP is in the format `GZR 1020`, so it will always fail for Maltese addresses.
🙏 