### PR TITLE
Allow NNNN zipcode for Argentina

### DIFF
--- a/lib/validates_zipcode/cldr_regex_collection.rb
+++ b/lib/validates_zipcode/cldr_regex_collection.rb
@@ -32,7 +32,7 @@ module ValidatesZipcode
       SG: /\A\d{6}\z/,
       DZ: /\A\d{5}\z/,
       AD: /\AAD\d{3}\z/,
-      AR: /\A[A-HJ-NP-Z]{1}\d{4}([A-Z]{3})?\z/,
+      AR: /\A([A-HJ-NP-Z]{1}\d{4}([A-Z]{3})?|\d{4})\z/,
       AM: /\A(37)?\d{4}\z/,
       BH: /\A(1[0-2]|[1-9])\d{2}\z/,
       BD: /\A\d{4}\z/,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -423,6 +423,7 @@ TEST_DATA = {
     valid: %w[
       C1234CHN
       C1234
+      6000
     ],
     invalid: [
       nil,


### PR DESCRIPTION
Add NNNN format to AR regexp

https://en.wikipedia.org/wiki/List_of_postal_codes

> Previously NNNN which is the minimum requirement as of 2006, but ANNNNAAA is not mandatory.