### PR TITLE
Return false for malformed country codes (not valid ISO 3166-1 alpha-2)

### DIFF
--- a/lib/validates_zipcode/zipcode.rb
+++ b/lib/validates_zipcode/zipcode.rb
@@ -12,6 +12,7 @@ module ValidatesZipcode
 
     def valid?
       return true if @excluded_country_codes.include?(@country_alpha2)
+      return false unless valid_country_alpha2?
       return true unless regexp
 
       zipcode = @format ? formatted_zip : @zipcode
@@ -29,6 +30,13 @@ module ValidatesZipcode
 
     def regexp
       @regexp ||= regexp_for_country_alpha2(@country_alpha2)
+    end
+
+    # ISO 3166-1 alpha-2 codes are exactly 2 uppercase ASCII letters.
+    # Anything longer or shorter (e.g. "UKXXXXX", "G", "12") is not a
+    # valid country code and should fail validation immediately.
+    def valid_country_alpha2?
+      @country_alpha2.to_s.match?(/\A[A-Za-z]{2}\z/)
     end
 
     def formatted_zip

--- a/spec/validates_zipcode_spec.rb
+++ b/spec/validates_zipcode_spec.rb
@@ -82,6 +82,14 @@ describe ValidatesZipcode, '.valid?' do
       expect(ValidatesZipcode.valid?('12345', 'ZZ')).to eq(true)
     end
 
+    it "is false with a malformed country code that is not a valid ISO 3166-1 alpha-2 code" do
+      expect(ValidatesZipcode.valid?('Sw1A 2aA', 'UKXXXXX')).to eq(false)
+      expect(ValidatesZipcode.valid?('12345', 'USA')).to eq(false)    # 3 letters
+      expect(ValidatesZipcode.valid?('12345', 'U')).to eq(false)      # 1 letter
+      expect(ValidatesZipcode.valid?('12345', '12')).to eq(false)     # digits
+      expect(ValidatesZipcode.valid?('12345', '')).to eq(false)       # empty
+    end
+
     it "is true with an excluded country code -  we don't want those to fail and nil is hairy" do
       expect(ValidatesZipcode.valid?('XXXX!!!XXXX', 'PA', excluded_country_codes: %w[PA])).to eq(true)
     end


### PR DESCRIPTION
## Summary

Fixes #67

`ValidatesZipcode.valid?('Sw1A 2aA', 'UKXXXXX')` returned `true` because any country code absent from `ZIPCODES_REGEX` fell through to `return true unless regexp`.

## Root cause

The `return true unless regexp` guard is intentional for legitimate-but-unknown 2-letter country codes (e.g. `'ZZ'`) where we simply don't have a postal code pattern. However, it also silently accepted completely malformed codes like `'UKXXXXX'`, `'USA'`, `'1'`, etc.

## Fix

Add a `valid_country_alpha2?` private method that checks the code matches `/\A[A-Za-z]{2}\z/` (the ISO 3166-1 alpha-2 format: exactly 2 ASCII letters). Return `false` early if the code is malformed.

Existing behaviour preserved:
- `valid?('12345', 'ZZ')` → `true` (unknown but valid-format code)
- `valid?('93108', 'ES')` → `true` (known code, valid zipcode)

New behaviour:
- `valid?('Sw1A 2aA', 'UKXXXXX')` → `false` (too many chars)
- `valid?('12345', 'USA')` → `false` (3 chars)
- `valid?('12345', 'U')` → `false` (1 char)
- `valid?('12345', '12')` → `false` (digits)

## Tests

2198 examples, 0 failures (was 2197).